### PR TITLE
New version with explicit pug template tags

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ module.exports = function (source) {
     this.cacheable();
     const options = loaderUtils.getOptions(this);
 
-    const regex = /template\:\s+`([^`]+)`/;
+    const regex = /pug\s*`([^`]+)`/;
 
     const matches = source.match(regex);
 
@@ -38,7 +38,7 @@ module.exports = function (source) {
     let data = this.query.data || {};
     let html = template(data);
 
-    let html_template = `template: \`${html}\``;
+    let html_template = `\`${html}\``;
 
     return source.replace(regex, html_template);
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Webpack loader that transform angular inline templates from pug into html ",
   "main": "lib/index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest --testEnvironment=\"node\""
   },
   "repository": {
     "type": "git",

--- a/test/input/html-template.js
+++ b/test/input/html-template.js
@@ -1,10 +1,11 @@
-
 function Component(moduleOrName, selector, options) {
     return {};
 }
 
+function pug(strings) {}
+
 const app = {}
 
 Component(app, selector, {
-    template: `<div class="test"><p>This should not be converted</p></div>`
+    template: pug`<div class="test"><p>This should not be converted</p></div>`
 })

--- a/test/input/indented-first-element.js
+++ b/test/input/indented-first-element.js
@@ -1,12 +1,13 @@
-
 function Component(moduleOrName, selector, options) {
     return {};
 }
 
+function pug(strings) {}
+
 const app = {}
 
 Component(app, selector, {
-    template: `
+    template: pug`
     .top-div-with-class
         .sub-div
             p Paragraph with text

--- a/test/input/multiple-root-element.js
+++ b/test/input/multiple-root-element.js
@@ -1,12 +1,13 @@
-
 function Component(moduleOrName, selector, options) {
     return {};
 }
 
+function pug(strings) {}
+
 const app = {}
 
 Component(app, selector, {
-    template: `
+    template: pug`
     .drop-shadow.monitor-component
         h3.overview-header.clearfix
             span.pull-left Project management and monitoring

--- a/test/input/new-style-component-whitespace-after-template-tag.js
+++ b/test/input/new-style-component-whitespace-after-template-tag.js
@@ -1,0 +1,10 @@
+function pug(strings) {}
+
+const template = pug `
+    .const-variable-with-class-and-whitespace-after-template-tag
+        .sub-div
+            p Paragraph with text
+`;
+
+export class NewStyleComponentWhiteSpaceAfterTemplateTag {
+}

--- a/test/input/new-style-component.js
+++ b/test/input/new-style-component.js
@@ -1,0 +1,11 @@
+function pug(strings) {}
+
+const template = pug`
+    .const-variable-with-class
+        .sub-div
+            p Paragraph with text
+`;
+
+export class NewStyleComponent {
+}
+

--- a/test/input/newline-first.js
+++ b/test/input/newline-first.js
@@ -1,12 +1,13 @@
-
 function Component(moduleOrName, selector, options) {
     return {};
 }
 
+function pug(strings) {}
+
 const app = {}
 
 Component(app, selector, {
-    template: `
+    template: pug`
 .top-div-with-class
     .sub-div
         p Paragraph with text

--- a/test/input/simple-pug-whitespace-after-template-tag.js
+++ b/test/input/simple-pug-whitespace-after-template-tag.js
@@ -1,0 +1,14 @@
+function Component(moduleOrName, selector, options) {
+    return {};
+}
+
+function pug(strings) {}
+
+const app = {}
+
+Component(app, selector, {
+    template:
+pug `.top-div-with-class
+    .sub-div
+        p Paragraph with text`
+})

--- a/test/input/simple-pug.js
+++ b/test/input/simple-pug.js
@@ -1,13 +1,14 @@
-
 function Component(moduleOrName, selector, options) {
     return {};
 }
+
+function pug(strings) {}
 
 const app = {}
 
 Component(app, selector, {
     template:
-`.top-div-with-class
+pug`.top-div-with-class
     .sub-div
         p Paragraph with text`
 })

--- a/test/input/whitespace-at-the-end.js
+++ b/test/input/whitespace-at-the-end.js
@@ -1,13 +1,14 @@
-
 function Component(moduleOrName, selector, options) {
     return {};
 }
+
+function pug(strings) {}
 
 const app = {}
 
 Component(app, selector, {
     template:
-        `.top-div-with-class
+        pug`.top-div-with-class
             .sub-div
                 p Paragraph with text
                 `

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,12 +1,12 @@
 import compiler from './compiler.js';
 
-test('Translates simpel template', async () => {
-  const stats = await compiler('input/simple-pug.js');
-  const output = stats.toJson().modules[0].source;
+test('Translates simple template', async () => {
+    const stats = await compiler('input/simple-pug.js');
+    const output = stats.toJson().modules[0].source;
 
-  expect(output.indexOf('<div class="top-div-with-class">') > 0).toBe(true);
-  expect(output.indexOf('<div class="sub-div">') > 0).toBe(true);
-  expect(output.indexOf('<p>Paragraph with text</p>') > 0).toBe(true);
+    expect(output.indexOf('<div class="top-div-with-class">') > 0).toBe(true);
+    expect(output.indexOf('<div class="sub-div">') > 0).toBe(true);
+    expect(output.indexOf('<p>Paragraph with text</p>') > 0).toBe(true);
 });
 
 test('Whitespace at the end of the template', async () => {
@@ -16,37 +16,68 @@ test('Whitespace at the end of the template', async () => {
     expect(output.indexOf('<div class="top-div-with-class">') > 0).toBe(true);
     expect(output.indexOf('<div class="sub-div">') > 0).toBe(true);
     expect(output.indexOf('<p>Paragraph with text</p>') > 0).toBe(true);
-  });
+});
 
-  test('Newline first in the template', async () => {
+test('Newline first in the template', async () => {
     const stats = await compiler('input/newline-first.js');
     const output = stats.toJson().modules[0].source;
 
     expect(output.indexOf('<div class="top-div-with-class">') > 0).toBe(true);
     expect(output.indexOf('<div class="sub-div">') > 0).toBe(true);
     expect(output.indexOf('<p>Paragraph with text</p>') > 0).toBe(true);
-  });
+});
 
-  test('Indented first element', async () => {
+test('Indented first element', async () => {
     const stats = await compiler('input/indented-first-element.js');
     const output = stats.toJson().modules[0].source;
 
     expect(output.indexOf('<div class="top-div-with-class">') > 0).toBe(true);
     expect(output.indexOf('<div class="sub-div">') > 0).toBe(true);
     expect(output.indexOf('<p>Paragraph with text</p>') > 0).toBe(true);
-  });
+});
 
-  test('Two root elements', async () => {
+test('Two root elements', async () => {
     const stats = await compiler('input/multiple-root-element.js');
     const output = stats.toJson().modules[0].source;
 
     expect(output.indexOf('<div class="drop-shadow monitor-component">') > 0).toBe(true);
     expect(output.indexOf('<debug-monitor-component admin-only-in-production') > 0).toBe(true);
-  });
+});
 
-  test('HTML template', async () => {
+test('HTML template', async () => {
     const stats = await compiler('input/html-template.js');
     const output = stats.toJson().modules[0].source;
 
-    expect(output.indexOf('template: `<div class="test"><p>This should not be converted</p></div>`') > 0).toBe(true);
-  });
+    expect(output.indexOf('template: pug`<div class="test"><p>This should not be converted</p></div>`') > 0).toBe(true);
+});
+
+test('simple template with whitespace after template tag', async () => {
+  const stats = await compiler('input/simple-pug-whitespace-after-template-tag.js');
+  const output = stats.toJson().modules[0].source;
+
+  expect(output.indexOf('<div class="top-div-with-class">') > 0).toBe(true);
+  expect(output.indexOf('<div class="sub-div">') > 0).toBe(true);
+  expect(output.indexOf('<p>Paragraph with text</p>') > 0).toBe(true);
+  expect(output.indexOf('pug`') > 0).toBe(false);
+});
+
+test('new style component', async () => {
+    const stats = await compiler('input/new-style-component.js');
+    const output = stats.toJson().modules[0].source;
+
+    expect(output.indexOf('<div class="const-variable-with-class">') > 0).toBe(true);
+    expect(output.indexOf('<div class="sub-div">') > 0).toBe(true);
+    expect(output.indexOf('<p>Paragraph with text</p>') > 0).toBe(true);
+    expect(output.indexOf('pug`') > 0).toBe(false);
+});
+
+test('new style component, with ', async () => {
+    const stats = await compiler('input/new-style-component-whitespace-after-template-tag.js');
+    const output = stats.toJson().modules[0].source;
+
+    expect(output.indexOf('<div class="const-variable-with-class-and-whitespace-after-template-tag">') > 0).toBe(true);
+    expect(output.indexOf('<div class="sub-div">') > 0).toBe(true);
+    expect(output.indexOf('<p>Paragraph with text</p>') > 0).toBe(true);
+    expect(output.indexOf('pug`') > 0).toBe(false);
+});
+


### PR DESCRIPTION
The "service refactoring" (as in "move to pure singleton imported ES6 class services") we've been working on has necessitated some changes to the structure of components, so we no longer use `@Component` decorators. Hence this library needed to change a bit.

previous component layout:
```ts
import { app } from './app';
import { Component } from '../decorators';

const selector = 'someComponent';

interface Bindings {
    //...
}

const bindings: Bindings = {
    // ...
};

@Component(app, selector, {
    template: `
        .top-div-with-class
            .sub-div
                p Paragraph with text
    `,
    bindings: bindings as {}
})
export class SomeComponent implements Bindings {
    static componentName = selector;
}
```
and they were magically registered into angularjs' DI by the decorator.
This doesn't really work well with modern libs and frameworks.

new component layout (deangularified):
```ts
const selector = 'someComponent';

const template = `
    .top-div-with-class
        .sub-div
            p Paragraph with text
`;

interface Bindings {
    //...
}

const bindings: Bindings = {
    // ...
};

export class SomeComponent implements Bindings {
    static componentName = selector;
}

export const ngSomeComponent = {
    [selector]: {
        template: template,
        bindings: bindings as {},
        controller: SomeComponent
    }
};
```

and this is then registered the traditional way in `some.module.ts` as follows:
```ts
import { module as ngModule } from 'angular';
import { ngSomeComponent } from './some.component.ts';

const some = ngModule('some', []);

some.component(ngSomeComponent);
```

So currently, this library can't find what to transpile since we moved from using `template: ` to `const template = `.

I have changed this, and at the same time required all pug transpilation to also have to use a tagged template string, the tag being `pug`. In JavaScript, that's just a function named `pug`, and it can be a dummy as long as in TS it appears to be returning a string for type checking reasons, but the implementation doesn't matter since this lib will strip it away and just return the raw string anyway.

So using the example above, in the end it would look like this:
```ts
const template = pug`
    .top-div-with-class
        .sub-div
            p Paragraph with text
`;
```

Would be great if you could merge this and publish a new version.

I didn't bother updating the docs since I was lazy and also there are no other users of the lib (understandably so since it's very tied to our setup).